### PR TITLE
add list of members who didn't show up

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -205,7 +205,7 @@ setInterval(async () => {
         const optKeyboard: telegramBot.SendMessageOptions = {
           parse_mode: "Markdown",
           reply_markup: {
-            keyboard: [[{ text: "Source Did not respond yet" }], [{ text: "Did not asked the report yet" }]]
+            keyboard: [[{ text: "yes" }], [{ text: "no" }]]
           }
         }
         const optRemove: telegramBot.SendMessageOptions = {
@@ -215,7 +215,7 @@ setInterval(async () => {
         }
         await bot.sendMessage(
           memberNameChatIdMap[reporterName],
-          `Just in case your source didn't show up, let us know.`,
+          `Did your source respond yet`,
           optKeyboard
         )
         var chatId = parseInt(memberNameChatIdMap[reporterName])

--- a/app.ts
+++ b/app.ts
@@ -120,7 +120,7 @@ setInterval(() => {
           { merge: true }
         )
         db.collection("members")
-        doc("sourceStatus")
+        .doc("sourceStatus")
         .update(
         {
           reporter: false

--- a/app.ts
+++ b/app.ts
@@ -220,7 +220,7 @@ setInterval(async () => {
         )
         var chatId = parseInt(memberNameChatIdMap[reporterName])
         responseCallbacks[chatId] = async response => {
-          var status = (response.text == "Source Did not respond yet") ? true : false
+          var status = (response.text == "no") ? true : false
           db.collection("members")
             .doc("sourceStatus")
             .update({

--- a/app.ts
+++ b/app.ts
@@ -119,6 +119,12 @@ setInterval(() => {
           },
           { merge: true }
         )
+        db.collection("members")
+        doc("sourceStatus")
+        .update(
+        {
+          reporter: false
+        })
     }
   }
 }, 1000 * 60)
@@ -196,6 +202,37 @@ setInterval(async () => {
       let memberData = memberDoc.data() as MemberData
       if (memberData[date].timeStamp === undefined) {
         let reporterName = memberData[date].reporter
+        const optKeyboard: telegramBot.SendMessageOptions = {
+          parse_mode: "Markdown",
+          reply_markup: {
+            keyboard: [[{ text: "Source Did not respond yet" }], [{ text: "Did not asked the report yet" }]]
+          }
+        }
+        const optRemove: telegramBot.SendMessageOptions = {
+          reply_markup: {
+            remove_keyboard: true
+          }
+        }
+        await bot.sendMessage(
+          memberNameChatIdMap[reporterName],
+          `Just in case your source didn't show up, let us know.`,
+          optKeyboard
+        )
+        var chatId = parseInt(memberNameChatIdMap[reporterName])
+        responseCallbacks[chatId] = async response => {
+          var status = (response.text == "Source Did not respond yet") ? true : false
+          db.collection("members")
+            .doc("sourceStatus")
+            .update({
+              reporterName: status
+            }
+            )
+          bot.sendMessage(
+            memberNameChatIdMap[reporterName],
+            `Alright, Thanks!`,
+            optRemove
+          )
+        }
         bot.sendMessage(
           memberNameChatIdMap[reporterName],
           `Hey there, This is a gentle reminder. Please submit your report soon using the /report command.`
@@ -223,6 +260,15 @@ setInterval(async () => {
       for (let idx = 0; idx < source.length; idx++) {
         let member = source[idx]
         const membersData = await db.collection("members").doc(member).get()
+        var sources = await db.collection("members")
+          .doc("sourceStatus")
+          .get()
+          .then( query => {
+          query._fieldsProto[source[idx]].booleanValue
+          })
+
+        sources && sourceNames.push(source[idx])
+
         const memberData = membersData.data() as MemberData
         if (memberData[date].timeStamp === undefined) {
           reporterNames.push(memberData[date].reporter)
@@ -238,6 +284,10 @@ setInterval(async () => {
       bot.sendMessage(
         oslGroupId,
         `Those who have not submitted the report yet:\n${reporterNames.join(
+          "\n"
+        )}
+        \n\n
+        Those who did not respond to their reporters yet:\n${sourceNames.join(
           "\n"
         )}`
       )


### PR DESCRIPTION
## Summary
This PR adds an enhancement which will ask the reporters on monday if their source didn't show up, in case that happens a separate list of the sources who didn't respond to their reporters will be sent on the osl-active telegram group.